### PR TITLE
Pack alacritty-with-sixel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,17 +1,14 @@
 name: "Build and populate cache"
 on:
-  pull_request:
-    branches-ignore:
-      - dev
   push:
     branches:
       - main
       - master
   schedule:
-    # rebuild everyday at 2:51
+    # rebuild every first day of the month at 0:00
     # TIP: Choose a random time here so not all repositories are build at once:
     # https://www.random.org/clock-times/?num=1&earliest=01%3A00&latest=08%3A00&interval=5&format=html&rnd=new
-    - cron:  '51 2 * * *'
+    - cron:  '0 0 1 * *'
   workflow_dispatch:
 jobs:
   tests:

--- a/default.nix
+++ b/default.nix
@@ -18,6 +18,7 @@
 
   wechat = pkgs.callPackage ./pkgs/wechat { };
   ttf-wps-fonts = pkgs.callPackage ./pkgs/ttf-wps-fonts { };
+  alacritty-with-sixel = pkgs.callPackage ./pkgs/alacritty-with-sixel { };
   # some-qt5-package = pkgs.libsForQt5.callPackage ./pkgs/some-qt5-package { };
   # ...
 }

--- a/pkgs/alacritty-with-sixel/default.nix
+++ b/pkgs/alacritty-with-sixel/default.nix
@@ -1,0 +1,36 @@
+{
+  pkgs,
+  lib,
+  ...
+}:
+pkgs.alacritty.override (
+  let
+    rp = pkgs.rustPlatform;
+  in
+  {
+    rustPlatform = rp // {
+      buildRustPackage =
+        args:
+        rp.buildRustPackage (
+          args
+          // {
+            version = "0.15.1";
+            src = pkgs.fetchFromGitHub {
+              owner = "ayosec";
+              repo = "alacritty";
+              rev = "814e8fefc60b4457ea155d11df9f27795de830ec";
+              hash = "sha256-NgA04vTAODp1g79Q/zvAYORdDypI/i5+kqq61mflc48=";
+            };
+            cargoHash = "sha256-Pr2VTPa/1SNr1W4NkxDKquj10uArR/M3WxVjhI1Ioko=";
+            meta = with lib; {
+              description = "Cross-platform, GPU-accelerated terminal emulator(With Sixel support)";
+              homepage = "https://github.com/ayosec/alacritty";
+              license = licenses.mit;
+              mainProgram = "alacritty";
+              platforms = platforms.unix;
+            };
+          }
+        );
+    };
+  }
+)


### PR DESCRIPTION
# Pack alacritty-with-sixel
Graphics can be added to the terminal using the Sixel protocol. Every graphic can have up to 1024 colors, and it is limited to 4096x4096 pixels.
# Update build.yml